### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # pyelotl-demos
-Demos that ilustrate pyelotl functionality using the prototyping package streamlit  
+Demos que muestran funcionalidad de pyelotl con el paquete de prototipado streamlit  
+
+## Instalación
+
+### 1. Instalar uv
+
+**Windows:**
+```bash
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+**macOS y Linux:**
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+📖 **Documentación completa de instalación**: [docs.astral.sh/uv/getting-started/installation](https://docs.astral.sh/uv/getting-started/installation/)
+
+### 2. Configurar el proyecto
+
+```bash
+# Crear entorno virtual e instalar dependencias
+uv venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+uv pip install -r pyproject.toml
+```
+
+## Uso
+
+```bash
+streamlit run app.py
+```
+
+## Documentación útil
+
+- **Guía de uv**: [docs.astral.sh/uv](https://docs.astral.sh/uv/)
+- **Streamlit**: [docs.streamlit.io](https://docs.streamlit.io/)
+- **uv para proyectos Python**: [docs.astral.sh/uv/guides/projects](https://docs.astral.sh/uv/guides/projects/)


### PR DESCRIPTION
Intentaba instalar las dependencias del proyecto con `python -m pip install -e .` y `uv build`, lo que me causaba errores. 

Agrego en el readme instrucciones más específicas para correr el proyecto en un entorno local. Utilizo uv porque el proyecto incluye un archivo uv.lock 